### PR TITLE
Fixed failing load JSON string from path

### DIFF
--- a/shared-textstyles.sketchplugin/Contents/Sketch/import.cocoascript
+++ b/shared-textstyles.sketchplugin/Contents/Sketch/import.cocoascript
@@ -23,7 +23,8 @@ function loadFonts(context, target) {
     open.runModal();
 
     var path = open.URLs().firstObject().path();
-    var fileContents = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:null];
+    var errorPtr = MOPointer.alloc().init()
+    var fileContents = NSString.stringWithContentsOfFile_encoding_error(path, NSUTF8StringEncoding, errorPtr);
     var stylesContents = JSON.parse(fileContents.toString());
     var styles = stylesContents.styles;
     var fonts = [];

--- a/shared-textstyles.sketchplugin/Contents/Sketch/import.cocoascript
+++ b/shared-textstyles.sketchplugin/Contents/Sketch/import.cocoascript
@@ -23,7 +23,7 @@ function loadFonts(context, target) {
     open.runModal();
 
     var path = open.URLs().firstObject().path();
-    var fileContents = NSString.stringWithContentsOfFile(path);
+    var fileContents = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:null];
     var stylesContents = JSON.parse(fileContents.toString());
     var styles = stylesContents.styles;
     var fonts = [];


### PR DESCRIPTION
## Cause

I'm not sure but I think `stringWithContentsOfFile` method was deprecated and it was removed from Foundation. I switched `stringWithContentsOfFile` to `stringWithContentsOfFile: encoding: error:` which existing now.

## Concerns

~~You wrote this CocoaScript using JavaScript style, but my code style is Objective-C. I tried to use JavaScript style but I didn't make it.  Sketch.app crashed.~~
I fixed coding style to JavaScript style. commit hash is 324e233.

## Issue

Related issue is #33